### PR TITLE
fixed definition of atan2 to include two arguments as per C89

### DIFF
--- a/source/abstraction_layer.rst
+++ b/source/abstraction_layer.rst
@@ -212,7 +212,7 @@ The following functions are built in and are defined as per ANSI C89:
 
 -  ``atanh(x)``
 
--  ``atan2(x)``
+-  ``atan2(y, x)``
 
 The following symbols are built in, and cannot be redefined,
 


### PR DESCRIPTION
This PR addresses Donal's bug report by updating the definition of atan2 to include to arguments as per the C89 specification